### PR TITLE
Fix users to accept first and last names

### DIFF
--- a/app/controllers/quote_requests_controller.rb
+++ b/app/controllers/quote_requests_controller.rb
@@ -42,7 +42,7 @@ class QuoteRequestsController < ApplicationController
 
   # TODO: find out what should be within the permit parentheses
   def quote_request_params
-    params.require(:quote_request).permit(:last_name, :phone)
+    params.require(:quote_request).permit(:email, :phone)
   end
   private :quote_request_params
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,7 +61,7 @@ class UsersController < ProtectedController
 
   def user_creds
     params.require(:credentials)
-          .permit(:email, :password, :password_confirmation)
+          .permit(:email, :password, :password_confirmation, :first_name, :last_name)
   end
 
   def pw_creds


### PR DESCRIPTION
The issue was in the users controller file where user_creds is defined:
the .permit() part only had the email and passwords. Added first and
last name symbols to that and now the table actually records those
values.